### PR TITLE
Fixed UI error when clicking on the Current Tithe

### DIFF
--- a/GuildTitheFrameScripts.lua
+++ b/GuildTitheFrameScripts.lua
@@ -171,7 +171,7 @@ end
 
 function E.FrameScript_MiniTitheFrameOnClick(self, button)
 	E:PrintDebug("MiniFrame OnClick()")
-	if IsAddOnLoaded("Blizzard_GuildBankUI") and GuildBankFrame:IsVisible() then
+	if C_AddOns.IsAddOnLoaded("Blizzard_GuildBankUI") and GuildBankFrame:IsVisible() then
 		E:DepositTithe(1)
 	elseif SendMailFrame:IsVisible() then
 		E:DepositTithe(1,1)


### PR DESCRIPTION
The IsAddOnLoaded function was apparently moved to the C_AddOns namespace. I updated the function to reflect this change.

This fixes the error that would occur when clicking on the "Current Tithe:" window.